### PR TITLE
Match leading spaces in var()

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -27,6 +27,7 @@ it("Shorten css variables", async () => {
 
 #firstParagraph {
   background-color: var(--first-color);
+  border-color: var( --second-color);
   color: var(--second-color);
 }
 
@@ -59,6 +60,7 @@ code {
 
 #firstParagraph {
   background-color: var(--0);
+  border-color: var( --1);
   color: var(--1);
 }
 

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ function map(j: import("postcss").Declaration) {
   }
 
   let value = j.value;
-  if (value && value.includes("var(--") && value.length <= 1000) {
+  if (value && value.match(/var\(\s*--/) && value.length <= 1000) {
     value = value.replace(/--[\w-_]{1,1000}/g, replacer);
     j.value = value;
   }


### PR DESCRIPTION
At the moment the plugin will miss variables inside `var()` functions if there are leading spaces, e.g. `color: var( --something)`.

This PR replaces the `includes` check for a more forgiving regex.
I've updated the unit test with a simple test case.